### PR TITLE
Use absolute imports

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,5 @@
-import "../styles/globals.css";
-import Layout from "../components/Layout";
+import "styles/globals.css";
+import Layout from "components/Layout";
 
 function MyApp({ Component, pageProps }) {
   return (

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { useState, useEffect, useMemo } from "react";
-import Table from "../components/UserTable";
+import Table from "components/UserTable";
 
 export default function Home() {
   let [users, setUsers] = useState([]);

--- a/pages/user/[publicId].js
+++ b/pages/user/[publicId].js
@@ -1,8 +1,8 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import EditProfileForm from "../../components/EditUserForm";
-import UserProfile from "../../components/UserProfile";
+import EditProfileForm from "components/EditUserForm";
+import UserProfile from "components/UserProfile";
 
 export default function UserPage() {
   const router = useRouter();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true, 
+    "baseUrl": "."
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
https://nextjs.org/docs/advanced-features/module-path-aliases

I wanted to make you aware of a handy feature - using absolute imports instead of relative imports. By setting the `"baseUrl"` property in the tsconfig.json file, you can then import modules "absolutely" from the baseUrl directory. For the most part, I assume WebStorm will be able to figure this stuff out, but in the case that you are manually typing your imports, being able to always import from the root of the project (as I've set in this PR as an example) can be useful, especially when you are 2+ directories deep from the module you are trying to import (e.g. `"../../components/Header"`).

We can talk more about project structure and some of my suggestions/best practices today, but this is one thing I would suggest as part of that.