### PR TITLE
Create API client module

### DIFF
--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -1,0 +1,23 @@
+import axios from "axios";
+
+export class Api {
+  constructor(config) {
+    this.client = axios.create(config);
+  }
+
+  async getUsers() {
+    let { data } = await this.client.get("/api/v1/user");
+    return data.body;
+  }
+
+  async getUserById(publicId) {
+    let { data } = await this.client.get(`/api/v1/user/${publicId}`);
+    return data.body;
+  }
+}
+
+export const api = new Api();
+
+export function createServerSideApiClient(config = {}) {
+  return new Api({ baseURL: "http://localhost:5000/", ...config });
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,6 @@
-import axios from "axios";
 import { useState, useEffect, useMemo } from "react";
 import Table from "components/UserTable";
+import { api } from "lib/api";
 
 export default function Home() {
   let [users, setUsers] = useState([]);
@@ -34,8 +34,8 @@ export default function Home() {
   useEffect(() => {
     async function getData() {
       try {
-        let response = await axios.get("/api/v1/user");
-        setUsers(response.data.body);
+        let users = await api.getUsers();
+        setUsers(users);
         setStatus("success");
       } catch (error) {
         setStatus("error");
@@ -45,7 +45,7 @@ export default function Home() {
     if (status === "loading") {
       getData();
     }
-  }, []);
+  }, [status]);
 
   return (
     <div>


### PR DESCRIPTION
This PR introduces an API client module for use both in the browser as well as on the server side. This was some refactoring we did last week that I wanted to put into a PR to show this pattern and how it can be helpful for having named methods to interact with your API. This abstraction (also known as the facade pattern) can also be helpful if you need to update the underlying HTTP library(s), which can then happen in one place instead of however many places you are making API calls.